### PR TITLE
feat(profile): set up profile service for masthead

### DIFF
--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
 import { User20 } from '@carbon/icons-react';
@@ -28,6 +28,7 @@ import {
   SideNavMenu,
   SideNavMenuItem,
 } from 'carbon-components-react';
+import { ProfileAPI } from '@ibmdotcom/services';
 import MastheadSearch from './MastheadSearch';
 import MastheadProfile from './MastheadProfile';
 import cx from 'classnames';
@@ -42,6 +43,23 @@ const { prefix } = settings;
  * @returns {*} Masthead component
  */
 const Masthead = ({ navigation }) => {
+  const [isAuthenticated, setStatus] = useState(false);
+
+  useEffect(() => {
+    /**
+     *  Login Status of user
+     *
+     *  @returns {*} User authentication status
+     */
+    async function loginStatus() {
+      return await ProfileAPI.getUserStatus();
+    }
+    const status = loginStatus();
+    setStatus(status.user === 'Authenticated');
+  }, []);
+
+  console.log('isAuthenticated', isAuthenticated);
+
   const navigationLinks = navigation.links;
 
   const className = cx({

--- a/packages/react/src/components/Masthead/Masthead.js
+++ b/packages/react/src/components/Masthead/Masthead.js
@@ -8,7 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
-import { User20 } from '@carbon/icons-react';
+import { User20, UserOnline20 } from '@carbon/icons-react';
 import { IbmLogo } from '../Icon';
 import {
   Header,
@@ -57,8 +57,6 @@ const Masthead = ({ navigation }) => {
     const status = loginStatus();
     setStatus(status.user === 'Authenticated');
   }, []);
-
-  console.log('isAuthenticated', isAuthenticated);
 
   const navigationLinks = navigation.links;
 
@@ -137,7 +135,8 @@ const Masthead = ({ navigation }) => {
                   overflowMenuProps={{
                     flipped: true,
                     style: { width: 'auto' },
-                    renderIcon: () => <User20 />,
+                    renderIcon: () =>
+                      isAuthenticated ? <UserOnline20 /> : <User20 />,
                   }}
                 />
               </HeaderGlobalAction>

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -34,6 +34,7 @@
     "jsdoc": "rimraf docs && jsdoc -c ./jsdoc.json ./README.md"
   },
   "dependencies": {
+    "jsonp": "^0.2.1",
     "window-or-global": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/services/src/services/Profile/Profile.js
+++ b/packages/services/src/services/Profile/Profile.js
@@ -1,0 +1,54 @@
+import jsonp from 'jsonp';
+
+/**
+ * @constant {string | string} Host for the profile status API call
+ * @private
+ */
+const _host = process.env.PROFILE_HOST || 'https://idaas.iam.ibm.com';
+
+/**
+ * @constant {string | string} API version
+ * @private
+ */
+const _version = process.env.PROFILE_VERSION || 'v1';
+
+/**
+ * Profile status endpoint
+ *
+ * @type {string}
+ * @private
+ */
+const _endpoint = `${_host}/${_version}/mgmt/idaas/user/status/`;
+
+/**
+ * Profile API class with methods for checking user authentication for ibm.com
+ */
+class ProfileAPI {
+  /**
+   * Returns user status (authenticated or unauthenticated)
+   *
+   * @returns {Promise<any>} User status
+   * @example
+   * import { ProfileAPI } from '@ibmdotcom/services';
+   * // or for tree-shaking:
+   * import { ProfileAPI } from '@ibmdotcom/services/es/services/Profile';
+   *
+   * async function getUserStatus() {
+   *   const response = await ProfileAPI.getUserStatus();
+   *   return response;
+   * }
+   */
+  static async getUserStatus() {
+    const url = _endpoint;
+
+    return await jsonp(url, null, function(err, data) {
+      if (err) {
+        console.error(err.message);
+      } else {
+        return data;
+      }
+    });
+  }
+}
+
+export default ProfileAPI;

--- a/packages/services/src/services/Profile/index.js
+++ b/packages/services/src/services/Profile/index.js
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './MarketingSearch';
-export * from './SearchTypeahead';
-export * from './Profile';
+export { default as ProfileAPI } from './Profile';


### PR DESCRIPTION
### Related Ticket(s)

[MyIBM profile background services](https://github.ibm.com/webstandards/digital-design/issues/778)

### Description

Set up profile service in order to determine whether user has logged in or not

### Changelog

**New**

- set up Profile service
- add logged in profile icon
- install `jsonp` package in order to call the endpoint
